### PR TITLE
Fixed Source searches and annotation support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations #for python3.8 or less
+
 import websockets, asyncio, yaml, json, sys, argparse
 import mido #type: ignore
 
@@ -150,7 +152,7 @@ if __name__ == "__main__":
     parser: argparse.ArgumentParser = argparse.ArgumentParser()
     parser.add_argument("--config", type = str, default = "settings.yaml")
     parser.add_argument("--port", type = str, default = "")
-    parser.add_argument("--debug", type = bool, default = False)
+    parser.add_argument("--debug", action = "store_true")
 
     args: argparse.Namespace = parser.parse_args()
 

--- a/messages.py
+++ b/messages.py
@@ -1,4 +1,6 @@
-#from typing import Optional
+from __future__ import annotations #for python3.8 or less
+
+
 from collections.abc import Generator
 
 from structures import OBS, Scene, Source, Filter
@@ -1161,6 +1163,7 @@ class Response:
                 self.obs.setCurrentScene(self.data["scene-name"])
 
             elif event == "ScenesChanged":
+                #self.obs.purgeScenes()
                 pass
 
             elif event == "SceneCollectionChanged":
@@ -1258,7 +1261,7 @@ class Response:
             elif event == "SourceCreated":
                 pass
 
-            elif event == "SourceDestoryed":
+            elif event == "SourceDestroyed":
                 pass
 
             elif event == "SourceVolumeChanged":

--- a/structures.py
+++ b/structures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations #for python3.8 or less
+
 from typing import Optional
 
 class OBS:
@@ -35,6 +37,15 @@ class OBS:
                 self.scenes.remove(scene)
                 return
 
+    def purgeScenes(self) -> None:
+        """Remove all scenes from the container"""
+
+
+        print("\n\nPurging scenes!\n\n")
+
+        self.scenes = []
+        self.requests.append({"type": "GetSceneList"})
+
     def getScene(self, name: str) -> Optional["Scene"]:
         """Returns reference to scene called name, if it exists."""
 
@@ -44,13 +55,13 @@ class OBS:
         return None
 
     def getSource(self, name: str) -> Optional["Source"]:
-        """Returns reference to source in any scene called name, if it exists."""
+        """Returns reference to source in active, if it exists."""
 
-        for scene in self.scenes:
-            for source in scene.sources:
-                if source.name == name:
-                    return source
+        for source in self.currentScene.sources:
+            if source.name == name:
+                return source
         return None
+        #TODO: Search in non-current scene
 
     def setCurrentScene(self, name: str) -> None:
         """Moves currentScene to previousScene and sets the named scene to current."""


### PR DESCRIPTION
Fixed issue where Sources that were searched for would only work if they were in the first scene that they appeared in, and added support for python versions 3.8 and below by importing annotations from \_\_future\_\_.